### PR TITLE
Add GitHub Actions workflow for Docker build and push

### DIFF
--- a/.github/workflows/dockerbuild.yaml
+++ b/.github/workflows/dockerbuild.yaml
@@ -1,0 +1,19 @@
+name: build-peer-server
+	
+  on:
+    push:
+      branches: [ main ]
+	
+  jobs:
+    build:
+      runs-on: ubuntu-latest
+	
+      steps:
+      - uses: actions/checkout@v2
+	
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: haeunseo/peer-server:latest


### PR DESCRIPTION
- Create a new workflow file `.github/workflows/build-and-push.yml`
- Configure the workflow to trigger on pushes to the `main` branch
- Use `docker/build-push-action` to build and push the Docker image to Docker Hub
- Tag the Docker image with `haeunseo/peer-server:latest`