### PR TITLE
[FIX] Oauth Login시 localhost:3000/oauth/callback으로 redirect되도록 변경

### DIFF
--- a/src/main/java/com/example/peer/oauth2/controller/GoogleController.java
+++ b/src/main/java/com/example/peer/oauth2/controller/GoogleController.java
@@ -1,11 +1,9 @@
 package com.example.peer.oauth2.controller;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +12,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.example.peer.oauth2.entity.OAuth2UserInfo;
 import com.example.peer.oauth2.service.LoginService;
+import com.example.peer.security.entity.TokenInfo;
 import com.example.peer.security.service.UserDetailsServiceImpl;
 import com.example.peer.security.utils.JwtTokenProvider;
 import com.example.peer.user.entity.OauthType;
@@ -49,7 +48,7 @@ public class GoogleController {
 	}
 
 	@GetMapping("/callback")
-	public ResponseEntity googleLogin(@RequestParam("code") String code) {
+	public void googleLogin(HttpServletResponse response, @RequestParam("code") String code) throws IOException {
 		OAuth2UserInfo oAuth2UserInfo = loginService.login(code, OauthType.GOOGLE);
 		Optional<User> optionalUser = loginService.findUserByOauthUserInfo(oAuth2UserInfo);
 		User user = null;
@@ -59,10 +58,13 @@ public class GoogleController {
 		} else {
 			user = optionalUser.get();
 		}
-		log.debug(">> user role: {}", user.getRole());
-		Map<String, Object> claims = user.getClaims();
-		claims.put("TokenInfo", jwtTokenProvider.generateToken(userDetailsService.loadUserById(user.getId())));
-		return ResponseEntity.ok().body(claims);
+		TokenInfo tokenInfo = jwtTokenProvider.generateToken(userDetailsService.loadUserById(user.getId()));
+		String uriString = UriComponentsBuilder
+			.fromUriString("https://localhost:3000/oauth/callback")
+			.toUriString();
+		response.addHeader("AccessToken", tokenInfo.getAccessToken());
+		response.addHeader("RefreshToken", tokenInfo.getRefreshToken());
+		response.sendRedirect(uriString);
 	}
 
 }

--- a/src/main/java/com/example/peer/oauth2/controller/NaverController.java
+++ b/src/main/java/com/example/peer/oauth2/controller/NaverController.java
@@ -1,11 +1,9 @@
 package com.example.peer.oauth2.controller;
 
 import java.io.IOException;
-import java.util.Map;
 import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -14,6 +12,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.example.peer.oauth2.entity.OAuth2UserInfo;
 import com.example.peer.oauth2.service.LoginService;
+import com.example.peer.security.entity.TokenInfo;
 import com.example.peer.security.service.UserDetailsServiceImpl;
 import com.example.peer.security.utils.JwtTokenProvider;
 import com.example.peer.user.entity.OauthType;
@@ -48,7 +47,8 @@ public class NaverController {
 	}
 
 	@GetMapping("/callback")
-	public ResponseEntity naverLogin(@RequestParam("code") String code) {
+	public void naverLogin(HttpServletResponse response, @RequestParam("code") String code) throws
+		IOException {
 		OAuth2UserInfo oAuth2UserInfo = loginService.login(code, OauthType.NAVER);
 		Optional<User> optionalUser = loginService.findUserByOauthUserInfo(oAuth2UserInfo);
 		User user = null;
@@ -59,8 +59,12 @@ public class NaverController {
 			log.debug(">> optional user was not empty");
 			user = optionalUser.get();
 		}
-		Map<String, Object> claims = user.getClaims();
-		claims.put("TokenInfo", jwtTokenProvider.generateToken(userDetailsService.loadUserById(user.getId())));
-		return ResponseEntity.ok().body(claims);
+		TokenInfo tokenInfo = jwtTokenProvider.generateToken(userDetailsService.loadUserById(user.getId()));
+		String uriString = UriComponentsBuilder
+			.fromUriString("https://localhost:3000/oauth/callback")
+			.toUriString();
+		response.addHeader("AccessToken", tokenInfo.getAccessToken());
+		response.addHeader("RefreshToken", tokenInfo.getRefreshToken());
+		response.sendRedirect(uriString);
 	}
 }


### PR DESCRIPTION
# 해결 하려는 문제 
- Oauth Login시 redirect를 하지 않으면 사용자 정보를 client측에서 받을 수 없는 문제 해결

# 해결한 방법
- 헤더에 token을 담아서 redirect하도록 변경