### PR TITLE
[FEAT] JWT로부터 User Id를 받아오는 서비스 구현 

### DIFF
--- a/src/main/java/com/example/peer/oauth2/entity/OAuth2UserInfo.java
+++ b/src/main/java/com/example/peer/oauth2/entity/OAuth2UserInfo.java
@@ -69,7 +69,7 @@ public record OAuth2UserInfo(
 			.socialId((socialId))
 			.name(name)
 			.email(email)
-			.profileImage(profile)
+			.profileImageUrl(profile)
 			.role(Role.MENTEE)
 			.build();
 	}

--- a/src/main/java/com/example/peer/security/controller/RefreshTokenController.java
+++ b/src/main/java/com/example/peer/security/controller/RefreshTokenController.java
@@ -6,7 +6,6 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -28,8 +27,10 @@ public class RefreshTokenController {
 	private final JwtTokenProvider jwtTokenProvider;
 	private final UserDetailsServiceImpl userDetailsService;
 	private static final Logger logger = LoggerFactory.getLogger(RefreshTokenController.class);
+
 	@PostMapping("/token/refresh")
-	public ResponseEntity tokenRefresh(@RequestHeader("Authorization") String authorization, @RequestBody String refreshToken) {
+	public ResponseEntity tokenRefresh(@RequestHeader("Authorization") String authorization,
+		@RequestBody String refreshToken) {
 		String accessToken = jwtTokenProvider.resolveToken(authorization);
 
 		logger.info("access token = {}, refresh Token = {}", accessToken, refreshToken);
@@ -42,13 +43,13 @@ public class RefreshTokenController {
 
 		// Access Token 만료 여부 확인
 		if (jwtTokenProvider.validateToken(accessToken).equals("Expired")) {
-			if (jwtTokenProvider.validateToken(refreshToken).equals("Expired")){
+			if (jwtTokenProvider.validateToken(refreshToken).equals("Expired")) {
 				throw new SecurityException(SecurityErrorCode.REFRESH_TOKEN_EXPIRED);
-			}
-			else{
+			} else {
 				Claims claims = jwtTokenProvider.parseClaims(accessToken);
 
-				TokenInfo tokenInfo = jwtTokenProvider.generateToken(userDetailsService.loadUserById(Long.valueOf(claims.get("id").toString())));
+				TokenInfo tokenInfo = jwtTokenProvider.generateToken(
+					userDetailsService.loadUserById(Long.valueOf(claims.getSubject())));
 				accessToken = tokenInfo.getAccessToken();
 				refreshToken = tokenInfo.getRefreshToken();
 			}

--- a/src/main/java/com/example/peer/security/service/TokenService.java
+++ b/src/main/java/com/example/peer/security/service/TokenService.java
@@ -1,0 +1,21 @@
+package com.example.peer.security.service;
+
+import org.springframework.stereotype.Service;
+
+import com.example.peer.security.utils.JwtTokenProvider;
+
+import io.jsonwebtoken.Claims;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class TokenService {
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public Long getUserIdFromToken(String accessToken) {
+		Claims claims = jwtTokenProvider.parseClaims(accessToken);
+		return Long.valueOf(claims.getSubject());
+	}
+}

--- a/src/main/java/com/example/peer/security/service/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/peer/security/service/UserDetailsServiceImpl.java
@@ -57,7 +57,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 		authorities.add(new SimpleGrantedAuthority(user.getRole().toString()));
 		log.debug(">> user name {}, authorities {}", user.getName(), authorities.toString());
 
-		return new org.springframework.security.core.userdetails.User(user.getName(), "password", authorities);
+		return new org.springframework.security.core.userdetails.User(user.getId().toString(), "password", authorities);
 
 	}
 

--- a/src/main/java/com/example/peer/security/utils/JwtTokenProvider.java
+++ b/src/main/java/com/example/peer/security/utils/JwtTokenProvider.java
@@ -35,9 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 public class JwtTokenProvider {
 	private final Key key;
 
-	// @Autowired
-	// RefreshTokenRepository refreshTokenRepository;
-
 	//    // 유저 정보를 가지고 AccessToken, RefreshToken 을 생성하는 메서드
 	public JwtTokenProvider(@Value("${spring.security.jwt.secret-key}") String secretKey) {
 		byte[] keyBytes = Decoders.BASE64.decode(secretKey);
@@ -48,7 +45,7 @@ public class JwtTokenProvider {
 		String authorities = user.getAuthorities().stream()
 			.map(GrantedAuthority::getAuthority)
 			.collect(Collectors.joining(","));
-
+		log.debug(">> creating token with username {}", user.getUsername());
 		String accessToken = Jwts.builder()
 			.setSubject(user.getUsername())
 			.claim("auth", authorities)

--- a/src/main/java/com/example/peer/user/entity/User.java
+++ b/src/main/java/com/example/peer/user/entity/User.java
@@ -5,7 +5,14 @@ import java.util.Map;
 
 import com.example.peer.common.domain.BaseTimeEntity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -40,15 +47,17 @@ public class User extends BaseTimeEntity {
 	private MentorDetail mentorDetail;
 
 	@Builder
-	public User(String name, String email, Role role, String phoneNumber, String profileImage, String socialId, OauthType oauthType) {
+	public User(String name, String email, Role role, String phoneNumber, String profileImageUrl, String socialId,
+		OauthType oauthType) {
 		this.name = name;
 		this.email = email;
 		this.role = role;
 		this.phoneNumber = phoneNumber;
-		this.profileImageUrl = profileImage;
+		this.profileImageUrl = profileImageUrl;
 		this.socialId = socialId;
 		this.oauthType = oauthType;
 	}
+
 	public Map<String, Object> getClaims() {
 		Map<String, Object> dataMap = new HashMap<>();
 		dataMap.put("userId", id);

--- a/src/test/java/com/example/peer/oauth2/controller/KakaoControllerTest.java
+++ b/src/test/java/com/example/peer/oauth2/controller/KakaoControllerTest.java
@@ -4,8 +4,6 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.DisplayName;
@@ -13,9 +11,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import com.example.peer.security.entity.TokenInfo;
@@ -26,7 +21,6 @@ import com.example.peer.user.entity.Role;
 import com.example.peer.user.entity.User;
 import com.example.peer.user.repository.UserRepository;
 
-import io.jsonwebtoken.Claims;
 import lombok.RequiredArgsConstructor;
 
 @SpringBootTest
@@ -43,12 +37,11 @@ class KakaoControllerTest {
 	private UserRepository userRepository;
 	private static final String base_mapping = "/oauth2/kakao";
 
-
 	String getAccessToken(String username) {
 		User user = User.builder()
 			.name(username)
 			.socialId("1")
-			.profileImage("/")
+			.profileImageUrl("/")
 			.role(Role.MENTEE)
 			.oauthType(OauthType.KAKAO)
 			.build();
@@ -69,10 +62,10 @@ class KakaoControllerTest {
 
 	@Test
 	@DisplayName("Access Token Test")
-	void accessTokenTest() throws Exception{
+	void accessTokenTest() throws Exception {
 		String accessToken = getAccessToken("username");
 		mockMvc.perform(get("/nothing")
-			.header("Authorization", "Bearer " + accessToken))
+				.header("Authorization", "Bearer " + accessToken))
 			.andExpect(status().isNotFound())
 			.andDo(print());
 	}

--- a/src/test/java/com/example/peer/security/service/TokenServiceTest.java
+++ b/src/test/java/com/example/peer/security/service/TokenServiceTest.java
@@ -1,0 +1,54 @@
+package com.example.peer.security.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import com.example.peer.security.entity.TokenInfo;
+import com.example.peer.security.utils.JwtTokenProvider;
+import com.example.peer.user.entity.OauthType;
+import com.example.peer.user.entity.Role;
+import com.example.peer.user.entity.User;
+import com.example.peer.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@SpringBootTest
+@RequiredArgsConstructor
+class TokenServiceTest {
+	@Autowired
+	UserRepository userRepository;
+	@Autowired
+	JwtTokenProvider jwtTokenProvider;
+	@Autowired
+	UserDetailsServiceImpl userDetailsService;
+	@Autowired
+	TokenService tokenService;
+
+	TokenInfo getTokenInfo() {
+		List<GrantedAuthority> authorities = new ArrayList<>();
+		authorities.add(new SimpleGrantedAuthority(Role.MENTEE.toString()));
+		User user = User.builder()
+			.name("name")
+			.role(Role.MENTEE)
+			.email("email@gmail.com")
+			.socialId("aa")
+			.oauthType(OauthType.NAVER)
+			.build();
+		userRepository.save(user);
+		TokenInfo tokenInfo = jwtTokenProvider.generateToken(userDetailsService.loadUserById(user.getId()));
+		return tokenInfo;
+	}
+
+	@Test
+	public void getUserIdFromTokenTest() {
+		TokenInfo tokenInfo = getTokenInfo();
+		Assertions.assertEquals(tokenService.getUserIdFromToken(tokenInfo.getAccessToken()), Long.valueOf(1));
+	}
+}


### PR DESCRIPTION
### 해결하려는 문제
---
- 통일되지 않은 User Entity Builder의 ProfileImageUrl 필드로 인한 빌드 실패 해결
- JWT로부터 User Id를 parse하는 메소드 구현

### 해결한 방법
---
- ProfileImageUrl 필드 통일
- TokenService를 생성하여 그 안에 `getUserIdFromToken(String AccessToken)` 메서드 생성